### PR TITLE
Fix like post comments behaviour

### DIFF
--- a/src/components/Feed/Modal/Comments/Comment.tsx
+++ b/src/components/Feed/Modal/Comments/Comment.tsx
@@ -59,7 +59,7 @@ function Comment({ comment, imageId }: CommentProps) {
   useEffect(() => {
     const authorCommentRef = ref(
       db,
-      `/image_comments/${imageId}/${comment.id}/likes`
+      `/comment_metrics/${comment.id}/likes`
     )
 
     onValue(

--- a/src/components/Feed/Modal/Comments/LikeComment.tsx
+++ b/src/components/Feed/Modal/Comments/LikeComment.tsx
@@ -28,7 +28,7 @@ function LikeComment({ imageId, commentId, isLiked, setIsLiked }: Props) {
     try {
       if (isLiked === true) {
         const updates = {
-          [`/image_comments/${imageId}/${commentId}/likes`]: increment(1),
+          [`/comment_metrics/${commentId}/likes`]: increment(1),
           [`/liked_comments/${imageId}/${userInfo.uid}/${commentId}`]: true,
         }
 
@@ -37,7 +37,7 @@ function LikeComment({ imageId, commentId, isLiked, setIsLiked }: Props) {
         setIsLiked(true)
       } else {
         const updates = {
-          [`/image_comments/${imageId}/${commentId}/likes`]: increment(-1),
+          [`/comment_metrics/${commentId}/likes`]: increment(-1),
           [`/liked_comments/${imageId}/${userInfo.uid}/${commentId}`]: null,
         }
 

--- a/src/components/Feed/Modal/index.tsx
+++ b/src/components/Feed/Modal/index.tsx
@@ -61,12 +61,11 @@ function Modal({ isOpen, onClose, imageInfo }: Props) {
         limitToLast(4)
       )
 
-      onValue(
-        imageCommentsRef,
-        (snapshot) =>
-          snapshot.exists() &&
+      onValue(imageCommentsRef, (snapshot) => {
+        if (snapshot.exists()) {
           setImageComments(Object.values<Comment>(snapshot.val()).reverse())
-      )
+        }
+      })
     } catch (err) {
       if (process.env.NODE_ENV === 'production') {
         captureException(err)


### PR DESCRIPTION
When displaying more than 4 comments, when one comment was liked the list of comments would get appended 4 more comments.

Reason: the comments were fetched using the `onValue` firebase method which syncs new data every single time any changes happens to its children or children of children. Thus, when liking a comment, the `onValue` would sync data again.