### PR TITLE
Image likes not starting at zero

### DIFF
--- a/src/pages/account/post.tsx
+++ b/src/pages/account/post.tsx
@@ -90,6 +90,8 @@ function Post() {
       const updates = {
         [`images/${userInfo.uid}/${imageID}`]: imageInfo,
         [`latest_images/${imageID}`]: imageInfo,
+        [`image_metrics/${imageID}/views`]: 0,
+        [`image_metrics/${imageID}/likes`]: 0,
       }
       await update(databaseRef(db), updates)
 


### PR DESCRIPTION
Previously, if the user would post a photo and someone opened that photo, the image views would increase but not the total of likes. Because of that, when hovering over a photo in the feed, the total of likes would display nothing.